### PR TITLE
`dekkingInTijdType`>`Tijdsbestek` toegevoegd

### DIFF
--- a/rdf/dekkingintijdtype.ttl
+++ b/rdf/dekkingintijdtype.ttl
@@ -48,5 +48,9 @@
   skos:broader <https://data.razu.nl/id/dekkingintijdtype/6647a78a0dc0920a5fa61df580cef511> ;
   skos:inScheme <https://data.razu.nl/id/dekkingintijdtype/21002589a45f08117d01f556b9defa6e> .
 
-
-
+<https://data.razu.nl/id/dekkingintijdtype/70a06aa707497017b24a599d24a4f9c9>
+  a skos:Concept ;
+  skos:prefLabel "Tijdsbestek"@nl ;
+  skos:note "Periode die door een object wordt gedekt, bijvoorbeeld de periode die een archief of dossier begrensd." ;
+  skos:broader <https://data.razu.nl/id/dekkingintijdtype/6647a78a0dc0920a5fa61df580cef511> ;
+    skos:inScheme <https://data.razu.nl/id/dekkingintijdtype/21002589a45f08117d01f556b9defa6e> .


### PR DESCRIPTION
# Context

Kunnen zien uit welke periode een archief stukken bevat lijkt mij handig. Wij willen dit bijvoorbeeld gaan gebruiken om in MDTO aan te geven: "Dit archief bevat vergaderingen/vergaderdossiers uit de periode 2010 - 2020", middels [`dekkingInTijdGegevens`](https://www.nationaalarchief.nl/archiveren/mdto/dekkingInTijdGegevens).

# Implementatie

Je kan een periode van deze aard nu aangeven door een nieuw concept `Tijdsbestek` aan te halen. Of dit een eigen/_sui generis_ concept is, of volledig samenvalt met een bestaand concept in deze lijst, lijkt me een punt van discussie. Benieuwd hoe jullie dat zien.

Dit concept een goeie naam geven was, zoals vaker, best lastig. "Tijdsbestek" is min of meer synoniem met "dekking in tijd". Probleem met het label "dekking in tijd" is dat dit vreemd gaat overkomen wanneer we het in  `mdto:dekkingInTijd`  gaan gebruiken. Maar ik ben ook oke met andere labels, al dan niet via `skos:altLabel`. 

Huidige ID is zo gemaakt:

```
printf Tijdsbestek | md5sum -
70a06aa707497017b24a599d24a4f9c9  -
```

# Alternatieven 

Er bestaat al een extreem algemeen concept wat een soort super algemene _temporal coverage_ aanduidt:

```ttl
<https://data.razu.nl/id/dekkingintijdtype/6647a78a0dc0920a5fa61df580cef511>
  a skos:Concept ;
  skos:prefLabel "Van toepassing"@nl ;
  skos:note "Periode waarin het object van toepassing is." ;
   ...
```

Ik struikel zelf alleen een beetje over het `prefLabel` hier. "Van toepassing zijn" heeft in mijn hoofd wat connotaties die het label `tijdsbestek` uit dit voorstel niet heeft. 

In ieder geval denk ik dat dit ... 

```xml
<naam>Archief met vergaderingen</naam>
...
<dekkingInTijd>
    <dekkingInTijdType>
	    <begripLabel>Van toepassing</begripLabel>
        ...
    </dekkingInTijdType>
    <dekkingInTijdBegindatum>2012</dekkingInTijdBegindatum>
    <dekkingInTijdEinddatum>2018</dekkingInTijdEinddatum>
</dekkingInTijd>
```

minder expliciet leest dan dit: 

```xml
<naam>Archief met vergaderingen</naam>
...
<dekkingInTijd>
    <dekkingInTijdType>
	    <begripLabel>Tijdsbestek</begripLabel>
        ...
    </dekkingInTijdType>
    <dekkingInTijdBegindatum>2012</dekkingInTijdBegindatum>
    <dekkingInTijdEinddatum>2018</dekkingInTijdEinddatum>
</dekkingInTijd>
```

Maar misschien dat dit op te lossen is door een `altLabel` toe te voegen naast `skos:prefLabel "Van toepassing"@nl`?  

Ben benieuwd wat je denk! 